### PR TITLE
Add Package-Requires header for ELPA installations

### DIFF
--- a/helm-delicious.el
+++ b/helm-delicious.el
@@ -6,7 +6,8 @@
 ;; Description: 
 ;; Author: thierry
 ;; Maintainer: 
-;; URL: 
+;; URL: https://github.com/emacs-helm/helm-delicious
+;; Package-Requires: ((helm "1.5.3"))
 ;; Keywords: 
 ;; Compatibility: 
  


### PR DESCRIPTION
Just a quick minor fix.

Also, can you comment on whether vapniks's fork is the new official home for this library? (https://github.com/vapniks/helm-delicious) He lists himself as maintainer, and is the owner of the Marmalade package.
